### PR TITLE
LLama image updtae

### DIFF
--- a/cloud-service-providers/azure/azureml/cli/config.sh
+++ b/cloud-service-providers/azure/azureml/cli/config.sh
@@ -39,8 +39,8 @@ image_name="<custom-name-for-nim-image>"
 ngc_container="nvcr.io/nim/meta/llama3-8b-instruct:latest"
 
 # Endpoint related information
-endpoint_name="llama-3-1-8b-nim-endpoint-aml-1"
+endpoint_name="llama-3-8b-nim-endpoint-aml-1"
 
 # Deployment related information
-deployment_name="llama3-1-8b-nim-deployment-aml-1"
+deployment_name="llama3-8b-nim-deployment-aml-1"
 instance_type="Standard_NC24ads_A100_v4"

--- a/cloud-service-providers/azure/azureml/cli/config.sh
+++ b/cloud-service-providers/azure/azureml/cli/config.sh
@@ -36,7 +36,7 @@ email_address="<your-email-address>"
  # NOTE: Verify that your AML workspace can access this ACR
 acr_registry_name="<your-azureml-registry-name>"
 image_name="<custom-name-for-nim-image>"
-ngc_container="nvcr.io/nim/meta/llama-3.1-8b-instruct:1.8.3"
+ngc_container="nvcr.io/nim/meta/llama3-8b-instruct:latest"
 
 # Endpoint related information
 endpoint_name="llama-3-1-8b-nim-endpoint-aml-1"

--- a/helm/nim-llm/values.yaml
+++ b/helm/nim-llm/values.yaml
@@ -49,7 +49,7 @@ extraVolumeMounts: {}
 ## @param image.tag [string] Image tag or version
 ## @param image.pullPolicy [string] Image pull policy
 image:
-  repository: nvcr.io/nim/meta/llama-3.1-8b-instruct
+  repository: nvcr.io/nim/meta/llama3-8b-instruct:latest
   pullPolicy: IfNotPresent
   # Tag overrides the image tag whose default is the chart appVersion.
   tag: "latest"
@@ -278,7 +278,7 @@ metrics:
 ## @param model.modelStorePath (deprecated) Specify location of unpacked model.
 model:
   nimCache: /model-store
-  name: meta/llama-3.1-8b-instruct # optional name of the model in the OpenAI API -- used in `helm test`
+  name: meta/llama3-8b-instruct # optional name of the model in the OpenAI API -- used in `helm test`
   ngcAPISecret: "ngc-api"
   ngcAPIKey: ""
   openaiPort: 8000


### PR DESCRIPTION
This pull request updates configuration files to standardize the naming and references for the Llama 3 8B instruct model across AzureML and Helm deployment scripts. The changes mainly involve updating image repository names, model names, and endpoint/deployment identifiers to ensure consistency.

Updates to model and image references:

* Changed the `image.repository` and `model.name` in `helm/nim-llm/values.yaml` to use `llama3-8b-instruct` instead of `llama-3.1-8b-instruct`, and updated to the latest tag for the image. [[1]](diffhunk://#diff-7fe1fac4aed45a8e94f73e7f3280943c5b4f2f068968e2eebdaa1cebe0791e46L52-R52) [[2]](diffhunk://#diff-7fe1fac4aed45a8e94f73e7f3280943c5b4f2f068968e2eebdaa1cebe0791e46L281-R281)

Updates to AzureML configuration:

* Updated the `endpoint_name` and `deployment_name` in `cloud-service-providers/azure/azureml/cli/config.sh` to match the new naming convention (`llama-3-8b-nim-endpoint-aml-1` and `llama3-8b-nim-deployment-aml-1`).